### PR TITLE
Update QnADialog.cs

### DIFF
--- a/QnAMakerDialog/QnAMakerDialog/QnADialog.cs
+++ b/QnAMakerDialog/QnAMakerDialog/QnADialog.cs
@@ -106,7 +106,7 @@ namespace QnAMakerDialog
                     new Dictionary<QnAMakerResponseHandlerAttribute, QnAMakerResponseHandler>(GetHandlersByMaximumScore());
             }
 
-            if (response.Answers.Any() && response.Answers.First().QnaId == -1)
+            if (response.Answers.Any() && (response.Answers.First().QnaId == -1 || response.Answers.First().QnaId == 0))
             {
                 await NoMatchHandler(context, queryText);
             }


### PR DESCRIPTION
case: user write question smth like "blahblahblah" and KB havnt answer for this.
idk why but when I expected call NoMatchHandler instead of '-1' "bad" QnaId I have answer with QnaId '0' - 'No good match found in KB.', so its broke this logic of checking:

response.Answers.First().QnaId == -1